### PR TITLE
update upload screens

### DIFF
--- a/app/views/questions/upload-form.html
+++ b/app/views/questions/upload-form.html
@@ -1,30 +1,32 @@
 {% set title = data['test-type'] %}
-{% set warning %}
-If your {{ title }} form is not complete, then it may cause problems with your application.
-{% endset %}
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    {{ govukInsetText({
-      text: warning
-    }) }}
     <form class="form" action="upload-supporting-documentation">
       <div class="govuk-caption-m">{{ title }}</div>
       <h1 class='govuk-heading-l'>Upload application form</h1>
       <p class="govuk-body">
-        Upload your completed {{ title }} form below.
+        Upload the official document you have completed to apply for a {{ title }}.
       </p>
-      {{ govukFileUpload({
-      id: "application-upload",
-      name: "application-upload",
-      label: {
-      html: "<strong>Upload application form</strong>"
-      }
-      }) }}
+
+      <div class="govuk-form-group">
+        <label class="govuk-label govuk-label govuk-!-font-weight-bold" for="supporting-documentation-upload">
+          Choose an application form to upload
+        </label>
+        <p class="govuk-body">The file must be smaller than 10MB and in either a .doc, .pdf, or .xls format.</p>
+        <input
+          class="govuk-file-upload"
+          id="sapplication-upload"
+          name="application-upload"
+          type="file"
+          multiple
+          errorMessage="The selected file must be a .doc, .pdf, or .xls format"
+        >
+      </div>
       {{ govukButton({
       text: "Save and continue"
       }) }}
     </form>
-    
+
   </div>
 </div>

--- a/app/views/questions/upload-form.html
+++ b/app/views/questions/upload-form.html
@@ -8,21 +8,16 @@
       <p class="govuk-body">
         Upload the official document you have completed to apply for a {{ title }}.
       </p>
-
-      <div class="govuk-form-group">
-        <label class="govuk-label govuk-label govuk-!-font-weight-bold" for="supporting-documentation-upload">
-          Choose an application form to upload
-        </label>
-        <p class="govuk-body">The file must be smaller than 10MB and in either a .doc, .pdf, or .xls format.</p>
-        <input
-          class="govuk-file-upload"
-          id="sapplication-upload"
-          name="application-upload"
-          type="file"
-          multiple
-          errorMessage="The selected file must be a .doc, .pdf, or .xls format"
-        >
-      </div>
+      {{ govukFileUpload({
+      id: "application-upload",
+      name: "application-upload",
+      label: {
+      html: "<strong>Choose an application form to upload</strong>"
+      },
+      hint: {
+        text: "The file must be smaller than 10MB and in either a .doc, .pdf, or .xls format."
+      }
+      }) }}
       {{ govukButton({
       text: "Save and continue"
       }) }}

--- a/app/views/questions/upload-supporting-documentation.html
+++ b/app/views/questions/upload-supporting-documentation.html
@@ -7,26 +7,49 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <div class="govuk-caption-m">{{ title }}</div>
-      <h1 class='govuk-heading-l'>Upload supporting documents</h1>
+      <h1 class='govuk-heading-l'>
+        Upload supporting documents
+       </h1>
       <p class="govuk-body">
-        Upload supporting documentation for your {{ title }} form below.
-      </p>
+        Upload extra information or evidence in support of your {{ title }} application.
+       </p>
+
       <div class="govuk-form-group">
         <label class="govuk-label govuk-label govuk-!-font-weight-bold" for="supporting-documentation-upload">
-          Upload supporting documentation
+          Choose supporting documents to upload
         </label>
-        <input class="govuk-file-upload" id="supporting-documentation-upload" name="supporting-documentation-upload" type="file" multiple>
+        <p class="govuk-body">Files must be smaller than 10MB and in either a .doc, .gif, .jpg, .pdf, .png, .txt, .xls, or .zip format.</p>
+        <input
+          class="govuk-file-upload"
+          id="supporting-documentation-upload"
+          name="supporting-documentation-upload"
+          type="file"
+          multiple
+          errorMessage="The selected file must be a .doc, .gif, .jpg, .pdf, .png, .txt, .xls, or .zip format"
+        >
       </div>
       <input type="submit" class="govuk-button govuk-button--secondary" name="upload-multiple" value="Upload">
       {% if data['supporting-documentation'] | length > 0 %}
-      <h3 class="govuk-heading-s">Uploaded files</h3>
-      <ul class="govuk-list">
-        {% for file in data['supporting-documentation'] %}
-        <li>{{ file }} – <a class="govuk-link govuk-link--no-visited-state" href="/remove-file?filename={{file}}">Remove<span class="govuk-visually-hidden"> {{ file }}</span></a></li>
+
+        <h3 class="govuk-heading-s">Uploaded files</h3>
+        <ul class="govuk-list">
+          {% for file in data['supporting-documentation'] %}
+            <div class="govuk-grid-row">
+              <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-1">
+                {{ file }}
+              </div>
+              <div class="govuk-grid-column-one-third">
+                <strong class="govuk-tag govuk-tag--green govuk-!-margin-right-2">Uploaded</strong>
+                <a class="govuk-link govuk-link--no-visited-state" href="/remove-file?filename={{file}}">Remove<span class="govuk-visually-hidden">
+                    {{ file }}</span></a>
+              </div>
+            </div>
+            <hr class="govuk-section-break--visible">
+          </li>
         {% endfor %}
       </ul>
-      {% endif %}
-    </div>
+    {% endif %}
   </div>
-  <input class="govuk-button" type="submit" value="Save and continue" name="continue">
+</div>
+<input class="govuk-button" type="submit" value="Save and continue" name="continue">
 </form>

--- a/app/views/questions/upload-supporting-documentation.html
+++ b/app/views/questions/upload-supporting-documentation.html
@@ -18,14 +18,14 @@
         <label class="govuk-label govuk-label govuk-!-font-weight-bold" for="supporting-documentation-upload">
           Choose supporting documents to upload
         </label>
-        <p class="govuk-body">Files must be smaller than 10MB and in either a .doc, .gif, .jpg, .pdf, .png, .txt, .xls, or .zip format.</p>
+        <p class="govuk-hint" id="supporting-documentation-upload-hint">Files must be smaller than 10MB and in either a .doc, .gif, .jpg, .pdf, .png, .txt, .xls, or .zip format.</p>
         <input
           class="govuk-file-upload"
           id="supporting-documentation-upload"
           name="supporting-documentation-upload"
+          aria-describedby="supporting-documentation-upload-hint"
           type="file"
           multiple
-          errorMessage="The selected file must be a .doc, .gif, .jpg, .pdf, .png, .txt, .xls, or .zip format"
         >
       </div>
       <input type="submit" class="govuk-button govuk-button--secondary" name="upload-multiple" value="Upload">
@@ -34,17 +34,18 @@
         <h3 class="govuk-heading-s">Uploaded files</h3>
         <ul class="govuk-list">
           {% for file in data['supporting-documentation'] %}
-            <div class="govuk-grid-row">
+          <li>
+            <div class="govuk-grid-row govuk-!-margin-bottom-1">
               <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-1">
                 {{ file }}
               </div>
               <div class="govuk-grid-column-one-third">
-                <strong class="govuk-tag govuk-tag--green govuk-!-margin-right-2">Uploaded</strong>
+                <strong class="govuk-tag govuk-tag--green govuk-!-margin-bottom-1 govuk-!-margin-right-2">Uploaded</strong>
                 <a class="govuk-link govuk-link--no-visited-state" href="/remove-file?filename={{file}}">Remove<span class="govuk-visually-hidden">
                     {{ file }}</span></a>
               </div>
             </div>
-            <hr class="govuk-section-break--visible">
+            <hr aria-hidden="true" class="govuk-section-break--visible govuk-!-margin-bottom-3">
           </li>
         {% endfor %}
       </ul>

--- a/product-codes-big-chat.md
+++ b/product-codes-big-chat.md
@@ -1,0 +1,29 @@
+# Product codes and the question flow
+
+## Big topic 1: per vehicle additional Qs
+* We're going to go vehicle first on everything, so regardless of whether or not it impacts the application the user has arrived to make, we'll learn the minimum about each vehicle to accurately choose a code for every application.
+* Intent is to get light vehicle details captured (IVA1C/MSVA/PMSVA) etc.
+* How do we feel about expanding this for PSV, trailer, HGV e.g. number of axles / number of seats / DDA schedules etc.
+* We may not get to it for VTG10 but we can explore a manual process for this.
+
+### The big lists
+
+It's going to be hard to get these tests to a single code without more vehicle info. A single price might be possible, but I think the code is crucial. There are others here e.g. 2/3 axle M3, VTG1/2 that we know about but these are a bit more involved:
+
+* COIF –  'CDL'/ 'CDS' / 'CEL' / 'CES' / 'CFL' / 'CFS' / 'CGL' / CGS' / 'CHL' / 'CHS'
+* 400B – '9GP' / '9HP' / '9IP' / '9JP' / '9KP'
+* VTG10 - 'NVV' / 'NFV' / 'NPV' / '10I' / '10R'
+* VTP5 – 'NFL' / 'NFS'
+* IVA Mutual – 'YXZ' / 'YSZ'
+* VTG59 – '00N' / '00M'?
+* Tempo 100 – 'TES' / 'TEL'
+
+## Big topic 2: out of hours testing
+
+* Statistically, I'm lead to believe this is rare if not non-existent. What can we do to move this issue out of our scope?
+* Suggestions include: charge / assign code assuming in-hours, have option for telephony to change and make additional charge later (???)
+
+## Big topic 3: Karen's POV on a location question
+
+* Is a "Are you taking your vehicle to a DVSA centre?" y/n enough?
+


### PR DESCRIPTION
- Updated content on /upload-form to match the wireframes in Lucid.
- Updated content on /upload-supporting-documentation to match the wireframes in Lucid.
- Added "Uploaded" tags next to each uploaded doc on /upload-supporting-documentation 
- Error message copy documented on Lucid, not the prototype 