### PR TITLE
Hidden recently selected test centres

### DIFF
--- a/app/views/questions/test-location.html
+++ b/app/views/questions/test-location.html
@@ -13,22 +13,22 @@
     {% endif %}
   </div>
 </div>
-    <form action="/test-location-check">
-      <div class="govuk-caption-m">{{ title }}</div>
-      <fieldset class="govuk-fieldset">
-        <div class="govuk-grid-row">
-          <div class="govuk-grid-column-two-thirds">
-            <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
-              <h1 class="govuk-fieldset__heading">
-                {{ question }}
-              </h1>
-            </legend>
-            <p id="find-test-centre-hint" class="govuk-hint">
+<form action="/test-location-check">
+  <div class="govuk-caption-m">{{ title }}</div>
+  <fieldset class="govuk-fieldset">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+          <h1 class="govuk-fieldset__heading">
+            {{ question }}
+          </h1>
+        </legend>
+        <p id="find-test-centre-hint" class="govuk-hint">
               This is a provisional selection and may change later, when you book your test. Even if you think your vehicle doesn't need an inspection, you must select an option. The DVSA reserves the right to
               inspect your vehicle.
             </p>
-          <div class="dvsa-panel__highlight">
-              {{ govukInput({
+        <div class="dvsa-panel__highlight">
+          {{ govukInput({
                   label: {
                     text: "Enter your preferred test centre"
                   },
@@ -38,32 +38,32 @@
                   classes: "govuk-input--width-10",
                   id: "find-test-centre",
                   name: "find-test-centre"
-                } | errorFilter(errors)) }} 
-            <button class="govuk-button" type="submit" name="find" value="find">
+                } | errorFilter(errors)) }}
+          <button class="govuk-button" type="submit" name="find" value="find">
               Find
             </button>
-          </div>
-          </div>
         </div>
-        <div class="govuk-grid-row">
-          <div class="govuk-grid-column-two-thirds  ">
-            <table class="govuk-table">
-              <caption class="govuk-table__caption govuk-table__caption--m">Recently selected test centres</caption>
-              <thead class="govuk-table__head">
-                <tr class="govuk-table__row">
-                  <th scope="col" class="govuk-table__header">
+      </div>
+    </div>
+    {# <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds  ">
+        <table class="govuk-table">
+          <caption class="govuk-table__caption govuk-table__caption--m">Recently selected test centres</caption>
+          <thead class="govuk-table__head">
+            <tr class="govuk-table__row">
+              <th scope="col" class="govuk-table__header">
                     Name
                   </th>
-                  <!-- <th scope="col" class="govuk-table__header">
+              <!-- <th scope="col" class="govuk-table__header">
                     Availability
                   </th> -->
-                  <th scope="col" class="govuk-table__header">
-                    <span class="govuk-visually-hidden">Select</span>
-                  </th>
-                </tr>
-              </thead>
-              <tbody class="govuk-table__body">
-              {% for testCentre in data.testCentres | limitTo(3) %}
+              <th scope="col" class="govuk-table__header">
+                <span class="govuk-visually-hidden">Select</span>
+              </th>
+            </tr>
+          </thead>
+          <tbody class="govuk-table__body">
+            {% for testCentre in data.testCentres | limitTo(3) %}
               <tr class="govuk-table__row">
                 <td class="govuk-table__cell">
                   {{ testCentre.name }}
@@ -76,11 +76,11 @@
                   <button class="govuk-button govuk-button--secondary govuk-!-margin-bottom-1" type="submit" name="select-test-centre" value="{{ testCentre.name }}">Select <span class="govuk-visually-hidden">{{ testCentre.name }}</span></button>
                 </td>
               </tr>
-              {% endfor %}
-            </table>
-          </div>
+            {% endfor %}
+          </table>
         </div>
-      </fieldset>
-    </form>
-  </div>
+      </div> #}
+  </fieldset>
+</form>
+</div>
 </div>


### PR DESCRIPTION
for the next sprint, the devs won't able to show the preferred test centre component. I've hidden this code in a comment, so when it's ready to be used, we can un-hide it.

Also updating the confluence design tracker to show no recently selected locations, one selected locations, and then more than one recently selected locations. Devs are building it out incrementally and want designs to reference it