### PR TITLE
Do not merge: Created un-linked results not found page

### DIFF
--- a/app/views/questions/results-not-found.html
+++ b/app/views/questions/results-not-found.html
@@ -1,0 +1,17 @@
+{% set mainClasses = "govuk-main-wrapper--l" %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-l">No results found</h1>
+      <p class="govuk-body">
+        There are no test centres that match your search. Try checking your search criteria and searching again.
+      </p>
+      {% from "govuk/components/button/macro.njk" import govukButton %}
+
+      {{ govukButton({
+      text: "Go back"
+    }) }}
+    </div>
+  </div>
+{% endblock %}


### PR DESCRIPTION
This is a stand alone page that isn't linked to any journey, just created for a screenshot for the devs. Devs wanted a view of what would happen in the edge case of a user inputting data into a find preferred test centre and we don't recognise their input. Different from error messages we've already created.